### PR TITLE
Add alternative text to author image

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -7,7 +7,6 @@ disableKinds = ["taxonomy", "term"]
 [author]
   name = "Lynx"
   image = "author.jpg"
-  alternative = "Lynx"
   links = [
     { link = { href = "https://github.com/jpanther/lynx/blob/stable/README.md", text = "View the readme", icon = "github" } },
     { link = { href = "styles/", text = "All the link styles", target = "_self" } },

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -7,6 +7,7 @@ disableKinds = ["taxonomy", "term"]
 [author]
   name = "Lynx"
   image = "author.jpg"
+  alternative = "Lynx"
   links = [
     { link = { href = "https://github.com/jpanther/lynx/blob/stable/README.md", text = "View the readme", icon = "github" } },
     { link = { href = "styles/", text = "All the link styles", target = "_self" } },

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,7 +2,7 @@
   <article class="flex flex-col items-center justify-center h-full mt-10 text-center">
     <header class="flex flex-col items-center mb-3">
       {{ with .Site.Author.image }}
-        <img class="mb-2 rounded-full w-36 h-36" src="{{ . | relURL }}" alt="{{ $.Site.Author.alternative }}" />
+        <img class="mb-2 rounded-full w-36 h-36" src="{{ . | relURL }}" alt="{{ $.Site.Author.name }}" />
       {{ end }}
       <h1 class="text-4xl font-extrabold dark:text-white">
         {{ .Params.title | default .Site.Author.name | default .Site.Title | emojify }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,7 +2,7 @@
   <article class="flex flex-col items-center justify-center h-full mt-10 text-center">
     <header class="flex flex-col items-center mb-3">
       {{ with .Site.Author.image }}
-        <img class="mb-2 rounded-full w-36 h-36" src="{{ . | relURL }}" />
+        <img class="mb-2 rounded-full w-36 h-36" src="{{ . | relURL }}" alt="{{ $.Site.Author.alternative }}" />
       {{ end }}
       <h1 class="text-4xl font-extrabold dark:text-white">
         {{ .Params.title | default .Site.Author.name | default .Site.Title | emojify }}


### PR DESCRIPTION
Getting an accessibilty error on https://wave.webaim.org/report#/stphnwlsh.github.io for missing alt text on the image.  This just adds the ability to add alternative text to the theme