### PR TITLE
Updating Mastodon Color

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -1088,7 +1088,7 @@ video {
 }
 
 .link-mastodon {
-  background-color: #338cd4;
+  background-color: #6364ff;
 }
 
 .link-medium {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -69,7 +69,7 @@
   background-color: #0077b5;
 }
 .link-mastodon {
-  background-color: #338cd4;
+  background-color: #6364ff;
 }
 .link-medium {
   background-color: #00ab6c;


### PR DESCRIPTION
<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/lynx/blob/dev/CONTRIBUTING.md -->

This PR updates the color for Mastodon to #6364ff. 

Here is the announcement of the new color: https://blog.joinmastodon.org/2022/06/mastodon-branding-updates/
And I have determined which color to use based on https://github.com/mastodon/blog/blob/master/static/style.css and https://github.com/simple-icons/simple-icons/issues/7662
