### PR TITLE
👷 Specify `HUGO_VERSION` environment variable once in `netlify.toml`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,22 +3,16 @@
   publish = "exampleSite/public"
 
 [build.environment]
+HUGO_VERSION = "0.112.7"
 HUGO_THEMESDIR = "../.."
 HUGO_THEME = "repo"
 TZ = "Australia/Melbourne"
 
 [context.production.environment]
-HUGO_VERSION = "0.112.7"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
 command = "cd exampleSite && hugo --gc --minify -D -b $DEPLOY_PRIME_URL"
 
-[context.deploy-preview.environment]
-HUGO_VERSION = "0.112.7"
-
 [context.branch-deploy]
 command = "cd exampleSite && hugo --gc --minify -D -b $DEPLOY_PRIME_URL"
-
-[context.branch-deploy.environment]
-HUGO_VERSION = "0.112.7"


### PR DESCRIPTION
## What does this PR do?

Fixes redundant environment variable specification across contexts.

## Explanation

The environment variable `HUGO_VERSION` holds the same value for all contexts (production, deploy-preview, and branch-deploy). Specifying it separately for each context becomes redundant.

Specifying it once under `[build.environment]` should be enough.

## Reference

From https://docs.netlify.com/configure-builds/file-based-configuration/#deploy-contexts :

>any property of a context-aware key, such as [build] or [[plugins]], will be applied to all contexts unless the same property key is present in a more specific context.