### PR TITLE
Fix ZgotmplZ for custom link style

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,43 @@
+# Development
+
+To make changes to CSS, edit:
+
+* `tailwind.config.js`
+* `assets/css/main.css`
+
+Then run `npm run build`.
+
+Output: `assets/css/compiled/main.css`
+
+To deploy to theme, copy the following to respective locations:
+
+* `assets/css/main.css`
+* `assets/css/compiled/main.css`
+
+## Notes about CSS changes
+
+### Choose light/dark/auto theme
+
+In `tailwind.confg.js`:
+
+```js
+  darkMode: "class",
+```
+
+is automatic light/dark selection by the browser.
+
+```js
+  darkMode: "media",
+```
+
+is manual selection by the theme's configuration.
+
+### Change background color everywhere
+
+In `assets/css/main.css`:
+
+```js
+html {
+  background-color: #B9AFA0;
+}
+```

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -80,7 +80,13 @@
   {{ with .Site.Author.name }}<meta name="author" content="{{ . }}" />{{ end }}
   {{ with .Site.Author.links }}
     {{ range $links := . }}
-      {{ range $name, $url := $links }}<link href="{{ $url }}" rel="me" />{{ end }}
+      {{ range $type, $data := $links }}
+        {{ $href := $data }}
+        {{ if reflect.IsMap $data }}
+          {{ with $data.href }}{{ $href = . }}{{ end }}
+        {{ end }}
+        <link href="{{ $href | safeURL }}" rel="me" />
+      {{ end }}
     {{ end }}
   {{ end }}
   {{/* Analytics */}}


### PR DESCRIPTION
Before this change, custom styles such as:

```
    { link = { text = "GitHub", href = "https://github.com/rlan" } },
```

in `config.toml` will result in

```html
      <link href="#ZgotmplZ" rel="me" />
```

This is because in the original code, `$url` will be a map type. The fix is similar to how it is handled in `layouts/index.html` at https://github.com/jpanther/lynx/blob/b4bf23e02f2ed1585feae310b1f29a27347a9da0/layouts/index.html#L44

