### PR TITLE
✨ New light/dark theme config feature: allow users to set and toggle theme colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,11 @@ Use the `params.light` and `params.dark` parameter structures to configure the l
     mainTextColor = "#ffffff"
     altTextColor = "#ffffff"
 }
+```
 
 - `bgColor` = background color
 - `mainTextColor` = title and body text color
 - `altTextColor` = subtitle and footer text color
-```
 
 You can modify the colors further by referring to the above section on custom CSS.
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,32 @@ Let's make a custom link for FontAwesome using the FA flag as the link icon and 
 
 When the site is rebuilt, the new custom link will appear.
 
+### Light / Dark theme configuration
+
+The light-dark toggle is disabled by default. To turn it on, set `toggle = true` in `params`.
+
+Use the `params.light` and `params.dark` parameter structures to configure the light and dark mode theme:
+
+```toml
+[params]
+  toggle = true
+  [params.light]
+    bgColor = "#ffffff"
+    mainTextColor = "#000000"
+    altTextColor = "#000000"
+  [params.dark]
+    bgColor = "#000000"
+    mainTextColor = "#ffffff"
+    altTextColor = "#ffffff"
+}
+
+- `bgColor` = background color
+- `mainTextColor` = title and body text color
+- `altTextColor` = subtitle and footer text color
+```
+
+You can modify the colors further by referring to the above section on custom CSS.
+
 ---
 
 ## Contributing

--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -1258,12 +1258,12 @@ video {
   color: rgb(55 65 81 / var(--tw-text-opacity));
 }
 
-@media (prefers-color-scheme: dark) {
+.dark-mode {
   .prose .chroma {
-    --tw-bg-opacity: 1;
-    background-color: rgb(55 65 81 / var(--tw-bg-opacity));
-    --tw-text-opacity: 1;
-    color: rgb(229 231 235 / var(--tw-text-opacity));
+      --tw-bg-opacity: 100%;
+      --tw-text-opacity: 100%;
+      background-color: color-mix(in srgb, #374151 var(--tw-bg-opacity), transparent calc(100% - var(--tw-bg-opacity)));
+      color: color-mix(in srgb, #e5e7eb var(--tw-text-opacity), transparent calc(100% - var(--tw-text-opacity)));
   }
 }
 
@@ -1435,27 +1435,12 @@ video {
   line-height: 1.75rem;
 }
 
-.text-neutral-400 {
-  --tw-text-opacity: 1;
-  color: rgb(156 163 175 / var(--tw-text-opacity));
-}
-
-.text-neutral-500 {
-  --tw-text-opacity: 1;
-  color: rgb(107 114 128 / var(--tw-text-opacity));
-}
-
-.text-neutral-800 {
+.title {
   --tw-text-opacity: 1;
   color: rgb(31 41 55 / var(--tw-text-opacity));
 }
 
-.text-neutral-900 {
-  --tw-text-opacity: 1;
-  color: rgb(17 24 39 / var(--tw-text-opacity));
-}
-
-@media (prefers-color-scheme: dark) {
+.dark-mode {
   .dark\:prose-invert {
     --tw-prose-body: var(--tw-prose-invert-body);
     --tw-prose-headings: var(--tw-prose-invert-headings);
@@ -1504,28 +1489,6 @@ video {
   text-decoration-color: #c084fc;
 }
 
-@media (prefers-color-scheme: dark) {
-  .dark\:bg-neutral-800 {
-    --tw-bg-opacity: 1;
-    background-color: rgb(31 41 55 / var(--tw-bg-opacity));
-  }
-
-  .dark\:text-neutral-400 {
-    --tw-text-opacity: 1;
-    color: rgb(156 163 175 / var(--tw-text-opacity));
-  }
-
-  .dark\:text-neutral-500 {
-    --tw-text-opacity: 1;
-    color: rgb(107 114 128 / var(--tw-text-opacity));
-  }
-
-  .dark\:text-white {
-    --tw-text-opacity: 1;
-    color: rgb(255 255 255 / var(--tw-text-opacity));
-  }
-}
-
 @media (min-width: 640px) {
   .sm\:min-w-0 {
     min-width: 0px;
@@ -1554,4 +1517,12 @@ video {
     padding-left: 8rem;
     padding-right: 8rem;
   }
+}
+
+/* Buttons */
+.btn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 10px 10px;
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -11,11 +11,10 @@
 
 /* Links */
 .link {
-  @apply text-white bg-primary-700 hover:brightness-90;
+  @apply text-main bg-primary-700 hover:brightness-90;
 }
 
 .link-amazon {
-  @apply text-neutral-900;
   background-color: #ff9900;
 }
 .link-apple {
@@ -59,7 +58,6 @@
   background-color: #33a0ff;
 }
 .link-kickstarter {
-  @apply text-neutral-900;
   background-color: #06ce78;
 }
 .link-lastfm {
@@ -96,7 +94,6 @@
   background-color: #4a154b;
 }
 .link-snapchat {
-  @apply text-neutral-900;
   background-color: #fffc00;
 }
 .link-soundcloud {

--- a/assets/css/theme-colors.css
+++ b/assets/css/theme-colors.css
@@ -1,0 +1,38 @@
+/* Light and dark themes */
+/* https://github.com/jpanther/lynx/blob/dev/assets/css/compiled/main.css */
+/* https://zwbetz.com/use-hugo-templating-in-your-external-css/ */
+
+/* Light theme */
+
+.bg-main {
+  --tw-bg-opacity: 90%;
+  background-color: color-mix(in srgb, {{ .Site.Params.light.bgColor | default "white" }} var(--tw-bg-opacity), transparent calc(100% - var(--tw-bg-opacity)));
+}
+
+.text-main {
+  --tw-text-opacity: 100%;
+  color: color-mix(in srgb, {{ .Site.Params.light.mainTextColor | default "black" }} var(--tw-text-opacity), transparent calc(100% - var(--tw-text-opacity)));
+}
+
+.text-alt {
+  --tw-text-opacity: 75%;
+  color: color-mix(in srgb, {{ .Site.Params.light.altTextColor | default "black" }} var(--tw-text-opacity), transparent calc(100% - var(--tw-text-opacity)));
+}
+
+.dark-mode {
+  .bg-main {
+    --tw-bg-opacity: 90%;
+    background-color: color-mix(in srgb, {{ .Site.Params.dark.bgColor | default "black" }} var(--tw-bg-opacity), transparent calc(100% - var(--tw-bg-opacity)));
+  }
+
+  .text-main {
+    --tw-text-opacity: 100%;
+    color: color-mix(in srgb, {{ .Site.Params.dark.mainTextColor | default "white" }} var(--tw-text-opacity), transparent calc(100% - var(--tw-text-opacity)));
+  }
+
+  .text-alt {
+    --tw-text-opacity: 75%;
+    color: color-mix(in srgb, {{ .Site.Params.dark.altTextColor | default "white" }} var(--tw-text-opacity), transparent calc(100% - var(--tw-text-opacity)));
+  }
+}
+

--- a/config.toml
+++ b/config.toml
@@ -8,54 +8,65 @@ title = "Lynx"
 enableEmoji = true
 disableKinds = ["taxonomy", "term"]
 
-[params.author]
-  # name = "Your name here"
-  # headline = "An awesome person"
-  # image = "img/author.jpg"  # path relative to static directory
+[params]
+  toggle = true # Theme toggle button visibility
+  # [params.light]
+  #   bgColor = "#ffffff"
+  #   mainTextColor = "#000000"
+  #   altTextColor = "#000000"
+  # [params.dark]
+  #   bgColor = "#000000"
+  #   mainTextColor = "#ffffff"
+  #   altTextColor = "#ffffff"
 
-  links = [
-    # { email = "mailto:hello@your_domain.com" },
-    # { link = "https://link-to-some-website.com/" },
-    # { amazon = "https://www.amazon.com/hz/wishlist/ls/wishlist-id" },
-    # { apple = "https://www.apple.com" },
-    # { codepen = "https://codepen.io/username" },
-    # { dev = "https://dev.to/username" },
-    # { discord = "https://discord.gg/invitecode" },
-    # { dribbble = "https://dribbble.com/username" },
-    # { facebook = "https://facebook.com/username" },
-    # { flickr = "https://www.flickr.com/photos/username/" },
-    # { foursquare = "https://foursquare.com/username" },
-    # { github = "https://github.com/username" },
-    # { gitlab = "https://gitlab.com/username" },
-    # { google = "https://www.google.com/" },
-    # { instagram = "https://instagram.com/username" },
-    # { keybase = "https://keybase.io/username" },
-    # { kickstarter = "https://www.kickstarter.com/profile/username" },
-    # { lastfm = "https://last.fm/user/username" },
-    # { linkedin = "https://linkedin.com/in/username" },
-    # { mastodon = "https://mastodon.instance/@username" },
-    # { medium = "https://medium.com/username" },
-    # { microsoft = "https://www.microsoft.com/" },
-    # { patreon = "https://www.patreon.com/username" },
-    # { pinterest = "https://pinterest.com/username" },
-    # { reddit = "https://reddit.com/user/username" },
-    # { slack = "https://workspace.url/team/userid" },
-    # { snapchat = "https://snapchat.com/add/username" },
-    # { soundcloud = "https://soundcloud.com/username" },
-    # { spotify = "https://spotify.com/user/username" },
-    # { stack-exchange = "https://stackexchange.com/users/userid/username" },
-    # { stack-overflow = "https://stackoverflow.com/users/userid/username" },
-    # { steam = "https://steamcommunity.com/profiles/userid" },
-    # { telegram = "https://t.me/username" },
-    # { threads = "https://threads.com/username" },
-    # { tiktok = "https://tiktok.com/@username" },
-    # { tumblr = "https://username.tumblr.com" },
-    # { twitch = "https://twitch.tv/username" },
-    # { twitter = "https://twitter.com/username" },
-    # { whatsapp = "https://wa.me/phone-number" },
-    # { x = "https://x.com/username" },
-    # { youtube = "https://youtube.com/username" },
-  ]
+  [params.author]
+    # name = "Your name here"
+    # headline = "An awesome person"
+    # image = "img/author.jpg"  # path relative to static directory
+
+    links = [
+      { email = "mailto:hello@your_domain.com" },
+      # { link = "https://link-to-some-website.com/" },
+      # { amazon = "https://www.amazon.com/hz/wishlist/ls/wishlist-id" },
+      # { apple = "https://www.apple.com" },
+      # { codepen = "https://codepen.io/username" },
+      # { dev = "https://dev.to/username" },
+      # { discord = "https://discord.gg/invitecode" },
+      # { dribbble = "https://dribbble.com/username" },
+      # { facebook = "https://facebook.com/username" },
+      # { flickr = "https://www.flickr.com/photos/username/" },
+      # { foursquare = "https://foursquare.com/username" },
+      # { github = "https://github.com/username" },
+      # { gitlab = "https://gitlab.com/username" },
+      # { google = "https://www.google.com/" },
+      # { instagram = "https://instagram.com/username" },
+      # { keybase = "https://keybase.io/username" },
+      # { kickstarter = "https://www.kickstarter.com/profile/username" },
+      # { lastfm = "https://last.fm/user/username" },
+      # { linkedin = "https://linkedin.com/in/username" },
+      # { mastodon = "https://mastodon.instance/@username" },
+      # { medium = "https://medium.com/username" },
+      # { microsoft = "https://www.microsoft.com/" },
+      # { patreon = "https://www.patreon.com/username" },
+      # { pinterest = "https://pinterest.com/username" },
+      # { reddit = "https://reddit.com/user/username" },
+      # { slack = "https://workspace.url/team/userid" },
+      # { snapchat = "https://snapchat.com/add/username" },
+      # { soundcloud = "https://soundcloud.com/username" },
+      # { spotify = "https://spotify.com/user/username" },
+      # { stack-exchange = "https://stackexchange.com/users/userid/username" },
+      # { stack-overflow = "https://stackoverflow.com/users/userid/username" },
+      # { steam = "https://steamcommunity.com/profiles/userid" },
+      # { telegram = "https://t.me/username" },
+      # { threads = "https://threads.com/username" },
+      # { tiktok = "https://tiktok.com/@username" },
+      # { tumblr = "https://username.tumblr.com" },
+      # { twitch = "https://twitch.tv/username" },
+      # { twitter = "https://twitter.com/username" },
+      # { whatsapp = "https://wa.me/phone-number" },
+      # { x = "https://x.com/username" },
+      # { youtube = "https://youtube.com/username" },
+    ]
 
 [module]
   [module.hugoVersion]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -4,17 +4,28 @@ title = "Lynx"
 enableEmoji = true
 disableKinds = ["taxonomy", "term"]
 
-[params.author]
-  name = "Lynx"
-  headline = "A simple links theme for Hugo built with Tailwind CSS"
-  image = "author.jpg"
-  links = [
-    { link = { href = "https://github.com/jpanther/lynx/blob/stable/README.md", text = "View the readme", icon = "github" } },
-    { link = { href = "styles/", text = "All the link styles", target = "_self" } },
-    { github = "https://github.com/jpanther/lynx" },
-    { x = "https://x.com/jpanther" },
-    { font-awesome = { href = "https://fontawesome.com/", text = "FontAwesome" } },
-  ]
+[params]
+  toggle = true # Theme toggle button visibility
+  [params.light]
+    bgColor = "#ffffff"
+    mainTextColor = "#000000"
+    altTextColor = "#7e22ce"
+  [params.dark]
+    bgColor = "#000000"
+    mainTextColor = "#ffffff"
+    altTextColor = "#cea922"
+
+  [params.author]
+    name = "Lynx"
+    headline = "A simple links theme for Hugo built with Tailwind CSS"
+    image = "author.jpg"
+    links = [
+      { link = { href = "https://github.com/jpanther/lynx/blob/stable/README.md", text = "View the readme", icon = "github" } },
+      { link = { href = "styles/", text = "All the link styles", target = "_self" } },
+      { github = "https://github.com/jpanther/lynx" },
+      { x = "https://x.com/jpanther" },
+      { font-awesome = { href = "https://fontawesome.com/", text = "FontAwesome" } },
+    ]
 
 [markup.highlight]
   noClasses = false

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 <html lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en{{ end }}">
   {{- partial "head.html" . -}}
   <body
-    class="flex flex-col h-screen px-6 m-auto text-lg leading-7 max-w-7xl bg-basic text-main sm:px-14 md:px-24 lg:px-32"
+    class="flex flex-col h-screen px-6 m-auto text-lg leading-7 max-w-7xl bg-main text-main sm:px-14 md:px-24 lg:px-32"
   >
     <main class="flex-grow">{{- block "main" . }}{{- end }}</main>
     {{- partial "footer.html" . -}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 <html lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en{{ end }}">
   {{- partial "head.html" . -}}
   <body
-    class="flex flex-col h-screen px-6 m-auto text-lg leading-7 bg-neutral max-w-7xl text-neutral-900 dark:bg-neutral-800 dark:text-white sm:px-14 md:px-24 lg:px-32"
+    class="flex flex-col h-screen px-6 m-auto text-lg leading-7 max-w-7xl bg-basic text-main sm:px-14 md:px-24 lg:px-32"
   >
     <main class="flex-grow">{{- block "main" . }}{{- end }}</main>
     {{- partial "footer.html" . -}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
       <a href="{{ "" | relURL }}" class="text-neutral-500">&larr; {{ i18n "nav.home" }}</a>
     </nav>
     <header>
-      <h1 class="mt-2 mb-6 text-4xl font-extrabold text-center text-neutral-800 dark:text-white">
+      <h1 class="mt-2 mb-6 text-4xl font-extrabold text-center title text-main">
         {{ .Title | emojify }}
       </h1>
     </header>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -11,5 +11,12 @@
     <section class="prose dark:prose-invert">
       {{ .Content | emojify }}
     </section>
+    {{ if .Site.Params.toggle | default false }}
+      <button class="btn light-to-dark" title="Switch to dark mode"><iconify-icon icon="mdi:lightbulb-night-outline"></iconify-icon></button>
+      <button class="btn dark-to-light" title="Switch to light mode"><iconify-icon icon="mdi:lightbulb-night"></iconify-icon></button>
+    {{ end }}
   </article>
+  {{ $templateStyle := resources.Get "css/theme-colors.css" }}
+  {{ $style := $templateStyle | resources.ExecuteAsTemplate "css/main.css" . }}
+  <link rel="stylesheet" type="text/css" href="{{ $style.Permalink }}">
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -20,11 +20,11 @@
           src="{{ $src }}"
         />
       {{ end }}
-      <h1 class="text-4xl font-extrabold dark:text-white">
+      <h1 class="text-4xl font-extrabold title text-main">
         {{ .Params.title | default .Site.Params.Author.name | default .Site.Title | emojify }}
       </h1>
       {{ with .Site.Params.Author.headline }}
-        <h2 class="text-xl text-neutral-500 dark:text-neutral-400">
+        <h2 class="text-xl headline text-alt">
           {{ . | markdownify | emojify }}
         </h2>
       {{ end }}
@@ -64,5 +64,12 @@
         {{ end }}
       </div>
     {{ end }}
+    {{ if .Site.Params.toggle | default false }}
+      <button class="btn light-to-dark" title="Switch to dark mode"><iconify-icon icon="mdi:lightbulb-night-outline"></iconify-icon></button>
+      <button class="btn dark-to-light" title="Switch to light mode"><iconify-icon icon="mdi:lightbulb-night"></iconify-icon></button>
+    {{ end }}
   </article>
+  {{ $templateStyle := resources.Get "css/theme-colors.css" }}
+  {{ $style := $templateStyle | resources.ExecuteAsTemplate "css/main.css" . }}
+  <link rel="stylesheet" type="text/css" href="{{ $style.Permalink }}">
 {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,7 +1,7 @@
 <footer class="py-10">
   <div class="text-center">
     {{/* Copyright */}}
-    <p class="text-sm text-neutral-500 dark:text-neutral-400">
+    <p class="text-sm copyright text-alt">
       {{- with .Site.Copyright }}
         {{ . | emojify | markdownify }}
       {{- else }}
@@ -12,7 +12,7 @@
     </p>
     {{/* Theme attribution */}}
     {{ if .Site.Params.attribution | default true }}
-      <p class="text-xs text-neutral-500 dark:text-neutral-400">
+      <p class="text-xs attribution text-alt">
         {{ $hugo := printf `<a class="hover:underline hover:decoration-primary-400 hover:text-primary-500"
           href="https://gohugo.io/" target="_blank" rel="noopener noreferrer">Hugo</a>`
         }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,3 +1,4 @@
+
 <head>
   <meta charset="utf-8" />
   {{ with .Site.LanguageCode }}
@@ -5,6 +6,27 @@
   {{ end }}
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+  {{/* https://icon-sets.iconify.design/mdi/lightbulb-night/ */}}
+  <script src="https://code.iconify.design/iconify-icon/1.0.7/iconify-icon.min.js"></script>
+  {{/* Check color scheme: https://www.ditdot.hr/en/dark-mode-website-tutorial */}}
+  <script>
+    window.onload = function(){
+      const d2l_button = document.querySelector(".btn.dark-to-light");
+      const l2d_button = document.querySelector(".btn.light-to-dark");
+
+      if (darkModeState) {
+        var d2l_disp = "";
+        var l2d_disp = "none";
+      } else {
+        var d2l_disp = "none";
+        var l2d_disp = "";
+      }
+
+      if (d2l_button) d2l_button.style.display = d2l_disp;
+      if (l2d_button) l2d_button.style.display = l2d_disp;
+    };
+  </script>
+  <script src="{{ "/js/toggle.js" | urlize | relURL }}"></script>
   {{/* Title */}}
   {{ if .IsHome -}}
     <title>{{ .Site.Title }}</title>

--- a/layouts/shortcodes/lead.html
+++ b/layouts/shortcodes/lead.html
@@ -1,3 +1,3 @@
-<p class="!mb-9 text-xl text-neutral-400 dark:text-neutral-500">
+<p class="!mb-9 text-xl text-main lead">
   {{ .Inner }}
 </p>

--- a/static/js/toggle.js
+++ b/static/js/toggle.js
@@ -1,0 +1,67 @@
+// https://www.ditdot.hr/en/dark-mode-website-tutorial
+
+// Toggles the "dark-mode" class
+function toggleDarkMode(state) {
+  document.documentElement.classList.toggle("dark-mode", state);
+  darkModeState = state;
+}
+
+// Sets localStorage state
+function setDarkModeLocalStorage(state) {
+  localStorage.setItem("dark-mode", state);
+}
+
+// Initial setting
+let darkModeState = (localStorage.getItem("color-scheme") == null) && (window.matchMedia("(prefers-color-scheme: dark)").matches) || (localStorage.getItem("color-scheme") == "dark-mode");
+toggleDarkMode(localStorage.getItem("dark-mode") == "true");
+
+// Toggles the "dark-mode" class on click and sets localStorage state
+window.addEventListener("DOMContentLoaded", (evt) => {
+  const d2l_button = document.querySelector(".btn.dark-to-light");
+  const l2d_button = document.querySelector(".btn.light-to-dark");
+
+  if (d2l_button && l2d_button) {
+    d2l_button.addEventListener("click", () => {
+      clicked = true;
+      // Switch to light mode
+      darkModeState = !darkModeState;
+      toggleDarkMode(darkModeState);
+      setDarkModeLocalStorage(darkModeState);
+
+      // Hide the dark-to-light button and show the light-to-dark button
+      d2l_button.style.display = "none";
+      l2d_button.style.display = "";
+    });
+    l2d_button.addEventListener("click", () => {
+      clicked = true;
+      // Switch to dark mode
+      darkModeState = !darkModeState;
+      toggleDarkMode(darkModeState);
+      setDarkModeLocalStorage(darkModeState);
+
+      // Hide the light-to-dark button and show the dark-to-light button
+      d2l_button.style.display = "";
+      l2d_button.style.display = "none";
+    });
+  }
+});
+
+// Listen for changes in the OS settings.
+// MediaQueryList object
+const useDark = window.matchMedia("(prefers-color-scheme: dark)");
+// Note: the arrow function shorthand works only in modern browsers,
+// for older browsers define the function using the function keyword.
+// https://stackoverflow.com/a/60000747
+try {
+  // Chrome & Firefox
+  useDark.addEventListener("change", (evt) => toggleDarkMode(evt.matches));
+} catch (e1) {
+  try {
+    // Safari
+    useDark.addListener((evt) => toggleDarkMode(evt.matches));
+  } catch (e2) {
+    console.error(e2);
+  }
+}
+
+


### PR DESCRIPTION
This PR includes the following features:

* Parameters for the user to configure the light mode and dark mode colors of the background, main text, and alt text of the site.
  - The default light theme is black text on a white background.
  - The default dark theme is white text on a black background.
* A button placed below all of the links for easy toggling between light and dark mode. (Default off)

---

Example configuration:

```toml
[params]
  toggle = true # Theme toggle button visibility
  [params.light]
    bgColor = "#fabe69"
    mainTextColor = "#0e2b47"
    altTextColor = "#3d2557"
  [params.dark]
    bgColor = "#302926"
    mainTextColor = "#b8e0de"
    altTextColor = "#dee036"

  [params.author]
    name = "Your name here"
    headline = "An awesome person"

    links = [
      { email = "mailto:hello@your_domain.com" },
      { link = "https://link-to-some-website.com/" },
      { github = "https://github.com/username" },
      { gitlab = "https://gitlab.com/username" },
      { spotify = "https://spotify.com/user/username" },
      { youtube = "https://youtube.com/username" },
    ]
```

Light mode result: 
![image](https://github.com/jpanther/lynx/assets/49991597/03128ef4-36cf-4c06-8162-932d73ae8574)

Dark mode result: 
![image](https://github.com/jpanther/lynx/assets/49991597/834905a9-160d-4b8a-9e69-d789ec28dfe9)

I successfully tested the toggling on Brave (essentially Chromium), Firefox, and Edge. The retention of toggled theme upon closing and reopening functions properly too.

---

I have also updated the README to reflect these new features.