### PR TITLE
Add Matrix support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Support for Matrix
+
 ## [1.4.0] - 2024-05-01
 
 ### Added

--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -606,7 +606,7 @@ video {
   list-style-type: decimal;
   margin-top: 1.25em;
   margin-bottom: 1.25em;
-  padding-inline-start: 1.625em;
+  padding-left: 1.625em;
 }
 
 .prose :where(ol[type="A"]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
@@ -649,7 +649,7 @@ video {
   list-style-type: disc;
   margin-top: 1.25em;
   margin-bottom: 1.25em;
-  padding-inline-start: 1.625em;
+  padding-left: 1.625em;
 }
 
 .prose :where(ol > li):not(:where([class~="not-prose"],[class~="not-prose"] *))::marker {
@@ -678,12 +678,12 @@ video {
   font-weight: 500;
   font-style: italic;
   color: var(--tw-prose-quotes);
-  border-inline-start-width: 0.25rem;
-  border-inline-start-color: var(--tw-prose-quote-borders);
+  border-left-width: 0.25rem;
+  border-left-color: var(--tw-prose-quote-borders);
   quotes: "\201C""\201D""\2018""\2019";
   margin-top: 1.6em;
   margin-bottom: 1.6em;
-  padding-inline-start: 1em;
+  padding-left: 1em;
 }
 
 .prose :where(blockquote p:first-of-type):not(:where([class~="not-prose"],[class~="not-prose"] *))::before {
@@ -773,9 +773,9 @@ video {
   font-size: 0.9rem;
   border-radius: 0.25rem;
   padding-top: 0.1875em;
-  padding-inline-end: 0.375em;
+  padding-right: 0.375em;
   padding-bottom: 0.1875em;
-  padding-inline-start: 0.375em;
+  padding-left: 0.375em;
   background-color: #e5e7eb;
   padding: 0.1rem 0.4rem;
 }
@@ -835,9 +835,9 @@ video {
   margin-bottom: 1.7142857em;
   border-radius: 0.375rem;
   padding-top: 0.8571429em;
-  padding-inline-end: 1.1428571em;
+  padding-right: 1.1428571em;
   padding-bottom: 0.8571429em;
-  padding-inline-start: 1.1428571em;
+  padding-left: 1.1428571em;
 }
 
 .prose :where(pre code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
@@ -863,7 +863,7 @@ video {
 .prose :where(table):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
   width: 100%;
   table-layout: auto;
-  text-align: start;
+  text-align: left;
   margin-top: 2em;
   margin-bottom: 2em;
   font-size: 0.875em;
@@ -879,9 +879,9 @@ video {
   color: var(--tw-prose-headings);
   font-weight: 600;
   vertical-align: bottom;
-  padding-inline-end: 0.5714286em;
+  padding-right: 0.5714286em;
   padding-bottom: 0.5714286em;
-  padding-inline-start: 0.5714286em;
+  padding-left: 0.5714286em;
 }
 
 .prose :where(tbody tr):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
@@ -970,11 +970,11 @@ video {
 }
 
 .prose :where(ol > li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  padding-inline-start: 0.375em;
+  padding-left: 0.375em;
 }
 
 .prose :where(ul > li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  padding-inline-start: 0.375em;
+  padding-left: 0.375em;
 }
 
 .prose :where(.prose > ul > li p):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
@@ -982,19 +982,19 @@ video {
   margin-bottom: 0.75em;
 }
 
-.prose :where(.prose > ul > li > p:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+.prose :where(.prose > ul > li > *:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
   margin-top: 1.25em;
 }
 
-.prose :where(.prose > ul > li > p:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+.prose :where(.prose > ul > li > *:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
   margin-bottom: 1.25em;
 }
 
-.prose :where(.prose > ol > li > p:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+.prose :where(.prose > ol > li > *:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
   margin-top: 1.25em;
 }
 
-.prose :where(.prose > ol > li > p:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+.prose :where(.prose > ol > li > *:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
   margin-bottom: 1.25em;
 }
 
@@ -1010,7 +1010,7 @@ video {
 
 .prose :where(dd):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
   margin-top: 0.5em;
-  padding-inline-start: 1.625em;
+  padding-left: 1.625em;
 }
 
 .prose :where(hr + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
@@ -1030,26 +1030,26 @@ video {
 }
 
 .prose :where(thead th:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  padding-inline-start: 0;
+  padding-left: 0;
 }
 
 .prose :where(thead th:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  padding-inline-end: 0;
+  padding-right: 0;
 }
 
 .prose :where(tbody td, tfoot td):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
   padding-top: 0.5714286em;
-  padding-inline-end: 0.5714286em;
+  padding-right: 0.5714286em;
   padding-bottom: 0.5714286em;
-  padding-inline-start: 0.5714286em;
+  padding-left: 0.5714286em;
 }
 
 .prose :where(tbody td:first-child, tfoot td:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  padding-inline-start: 0;
+  padding-left: 0;
 }
 
 .prose :where(tbody td:last-child, tfoot td:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  padding-inline-end: 0;
+  padding-right: 0;
 }
 
 .prose :where(figure):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
@@ -1177,6 +1177,10 @@ video {
 
 .link-mastodon {
   background-color: #6364ff;
+}
+
+.link-matrix {
+  background-color: #000;
 }
 
 .link-medium {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -78,6 +78,9 @@
 .link-mastodon {
   background-color: #6364ff;
 }
+.link-matrix {
+  background-color: #000;
+}
 .link-medium {
   background-color: #00ab6c;
 }

--- a/assets/icons/matrix.svg
+++ b/assets/icons/matrix.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   aria-hidden="true"
+   focusable="false"
+   data-prefix="fab"
+   data-icon="mastodon"
+   class="svg-inline--fa fa-mastodon fa-w-14"
+   role="img"
+   viewBox="0 0 448 512"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="matrix.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#000000"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="true"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.547699"
+     inkscape:cx="264.58633"
+     inkscape:cy="256.18676"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1"
+     showborder="true" />
+  <path
+     style="fill:none;stroke:#ffffff;stroke-width:17;stroke-dasharray:none;stroke-opacity:1"
+     d="m 322.9571,69.849186 h 89.36401 V 439.1878 H 322.3766"
+     id="path6-5" />
+  <path
+     style="fill:none;stroke:#ffffff;stroke-width:17;stroke-dasharray:none;stroke-opacity:1"
+     d="M 124.25704,74.372 H 34.89303 v 369.33862 h 89.94451"
+     id="path6" />
+  <text
+     xml:space="preserve"
+     style="font-size:266.667px;fill:#ffffff;fill-opacity:1"
+     x="95.65873"
+     y="340.44382"
+     id="text1"><tspan
+       sodipodi:role="line"
+       id="tspan1"
+       x="95.65873"
+       y="340.44382"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:266.667px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#ffffff;fill-opacity:1">m</tspan></text>
+</svg>

--- a/config.toml
+++ b/config.toml
@@ -36,6 +36,7 @@ disableKinds = ["taxonomy", "term"]
     # { lastfm = "https://last.fm/user/username" },
     # { linkedin = "https://linkedin.com/in/username" },
     # { mastodon = "https://mastodon.instance/@username" },
+    # { matrix = "https://matrix.to/#/#community:matrix.instance" },
     # { medium = "https://medium.com/username" },
     # { microsoft = "https://www.microsoft.com/" },
     # { patreon = "https://www.patreon.com/username" },

--- a/exampleSite/content/styles.md
+++ b/exampleSite/content/styles.md
@@ -29,6 +29,7 @@ These are all the built-in link styles available in Lynx. Don't forget that you 
 {{< link lastfm >}}
 {{< link linkedin >}}
 {{< link mastodon >}}
+{{< link matrix >}}
 {{< link medium >}}
 {{< link microsoft >}}
 {{< link patreon >}}

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -21,6 +21,7 @@ link:
   link: Website
   linkedin: LinkedIn
   mastodon: Mastodon
+  matrix: Matrix
   medium: Medium
   microsoft: Microsoft
   orcid: ORCiD

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -21,6 +21,7 @@ link:
   link: "Site internet"
   linkedin: LinkedIn
   mastodon: Mastodon
+  matrix: Matrix
   medium: Medium
   microsoft: Microsoft
   orcid: ORCiD


### PR DESCRIPTION
According to [the discussion](https://github.com/jpanther/lynx/discussions/157), this pull request adds an icon, style, etc. to support Matrix.

## Remark

I generated `assets/css/compiled/main.css` by `npm build`. However, it seems like all `padding-inline-`s were changed to `padding-left-`s. Please suggest me how to fix this if it is needed.