### PR TITLE
fix: Update theme to work with Hugo >= 0.146.0

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -62,4 +62,4 @@ disableKinds = ["taxonomy", "term"]
 [module]
   [module.hugoVersion]
     extended = false
-    min = "0.86.1"
+    min = "0.158.0"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,7 +7,7 @@
       {{- else }}
         &copy;
         {{ now.Format "2006" }}
-        {{ .Site.Author.name | markdownify | emojify }}
+        {{ .Site.Params.author.name | markdownify | emojify }}
       {{- end }}
     </p>
     {{/* Theme attribution */}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -77,8 +77,8 @@
     {{ hugo.Generator }}
   {{ end }}
   {{/* Me */}}
-  {{ with .Site.Author.name }}<meta name="author" content="{{ . }}" />{{ end }}
-  {{ with .Site.Author.links }}
+  {{ with .Site.Params.author.name }}<meta name="author" content="{{ . }}" />{{ end }}
+  {{ with .Site.Params.author.links }}
     {{ range $links := . }}
       {{ range $name, $url := $links }}<link href="{{ $url }}" rel="me" />{{ end }}
     {{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = "exampleSite/public"
 
 [build.environment]
-HUGO_VERSION = "0.118.2"
+HUGO_VERSION = "0.158.0"
 HUGO_THEMESDIR = "../.."
 HUGO_THEME = "repo"
 TZ = "Australia/Melbourne"


### PR DESCRIPTION
When using the theme with Hugo >= 0.146.0, the following error appears:

```
ERROR error building site: render: [en v1.0.0 guest] failed to render pages: render of "/" failed: "/Users/<username>/Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/jpanther/lynx@v1.4.0/layouts/_default/baseof.html:3:6":
execute of template failed: template: index.html:3:6: executing "index.html" at <partial "head.html" .>: error calling partial: "/Users/<username>/Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/jpanther/lynx@v1.4.0/layouts/partials/head.html:80:15":
execute of template failed: template: _partials/head.html:80:15: executing "_partials/head.html" at <.Site.Author.name>: can't evaluate field Author in type page.Site
```

This PR fixes these errors.

See https://gohugo.io/methods/site/params/ for more info.