### PR TITLE
Update Parameters for new Hugo Versions

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en{{ end }}">
+<html lang="{{ with .Site.Language.Locale }}{{ . }}{{ else }}en{{ end }}">
   {{- partial "head.html" . -}}
   <body
     class="bg-neutral m-auto flex h-screen max-w-7xl flex-col px-6 text-lg leading-7 text-neutral-900 sm:px-14 md:px-24 lg:px-32 dark:bg-neutral-800 dark:text-white"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -77,8 +77,8 @@
     {{ hugo.Generator }}
   {{ end }}
   {{/* Me */}}
-  {{ with .Site.Author.name }}<meta name="author" content="{{ . }}" />{{ end }}
-  {{ with .Site.Author.links }}
+  {{ with .Site.Params.Author.name }}<meta name="author" content="{{ . }}" />{{ end }}
+  {{ with .Site.Params.Author.links }}
     {{ range $links := . }}
       {{ range $name, $url := $links }}<link href="{{ $url }}" rel="me" />{{ end }}
     {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,6 @@
 <head>
   <meta charset="utf-8" />
-  {{ with .Site.LanguageCode }}
+  {{ with .Site.Language.Locale }}
     <meta http-equiv="content-language" content="{{ . }}" />
   {{ end }}
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/lynx/blob/dev/CONTRIBUTING.md -->

This PR fixes two error messages I encountered when using Hugo v0.162.0:

**Deprecated in v0.124.0:**

> ERROR error building site: render: [de v1.0.0 guest] failed to render pages: render of "/var/home/johannes/Projects/clara-und-johannes.de/content/_index.md" failed: "/var/home/johannes/.cache/hugo_cache/modules/filecache/modules/pkg/mod/github.com/jpanther/lynx@v1.4.0/layouts/_default/baseof.html:3:6": execute of template failed: template: index.html:3:6: executing "index.html" at <partial "head.html" .>: error calling partial: "/var/home/johannes/.cache/hugo_cache/modules/filecache/modules/pkg/mod/github.com/jpanther/lynx@v1.4.0/layouts/partials/head.html:80:15": execute of template failed: template: _partials/head.html:80:15: executing "_partials/head.html" at <.Site.Author.name>: can't evaluate field Author in type page.Site

**Deprecated in v0.158.0:**

> WARN  deprecated: .Site.LanguageCode was deprecated in Hugo v0.158.0 and will be removed in a future release. Use .Site.Language.Locale instead.
